### PR TITLE
Add handling of Sequelize "type" option for indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# List of changes from Scimonster fork
+- Indexes
+  - Handle "type" option = 'UNIQUE|FULLTEXT|SPATIAL'
+
+
+
+
 # sequelize-auto-migrations
 Migration generator &amp;&amp; runner for sequelize
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -154,7 +154,7 @@ const parseIndex = function(idx)
     // @todo: UNIQUE|FULLTEXT|SPATIAL
     if (idx.unique)
         options.type = options.indicesType = 'UNIQUE';
-    else (idx.type)
+    else if (idx.type)
         options.type = options.indicesType = idx.type;
 
     if (idx.method)

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -154,6 +154,8 @@ const parseIndex = function(idx)
     // @todo: UNIQUE|FULLTEXT|SPATIAL
     if (idx.unique)
         options.type = options.indicesType = 'UNIQUE';
+    else (idx.type)
+        options.type = options.indicesType = idx.type;
 
     if (idx.method)
         options.indexType = idx.type; // Set a type for the index, e.g. BTREE. See the documentation of the used dialect


### PR DESCRIPTION
I suggest the following simple change to enable users to create FULLTEXT indexes with latest Sequelize versions.

I tested in on a MySQL base